### PR TITLE
automatic outlier detection

### DIFF
--- a/R/outlier_bin.R
+++ b/R/outlier_bin.R
@@ -23,8 +23,8 @@
 
 gg_outlier_bin <- function(x,
                            var_name,
-                           cut_off_floor,
-                           cut_off_ceiling,
+                           cut_off_floor = NA,
+                           cut_off_ceiling = NA,
                            col = "black",
                            fill = "cornflowerblue",
                            fill_outlier_bins = "forestgreen",

--- a/R/outlier_bin.R
+++ b/R/outlier_bin.R
@@ -29,7 +29,11 @@ gg_outlier_bin <- function(x,
                            fill = "cornflowerblue",
                            fill_outlier_bins = "forestgreen",
                            binwidth = NULL) {
-
+  vector <- x %>% select_(var_name) %>% as.vector() %>% unlist()
+  outlier_range <-  1.5*IQR(vector)
+  cut_off_floor   =  quantile(vector,c(.25))[[1]] - outlier_range
+  cut_off_ceiling =   quantile(vector,c(.75))[[1]] + outlier_range
+  
   printing_min_max <- x %>% summarise_(sprintf("round(min(%s, na.rm = TRUE), 1)", var_name),
                                        sprintf("round(max(%s, na.rm = TRUE), 1)", var_name))
 

--- a/R/outlier_bin.R
+++ b/R/outlier_bin.R
@@ -31,9 +31,12 @@ gg_outlier_bin <- function(x,
                            binwidth = NULL) {
   vector <- x %>% select_(var_name) %>% as.vector() %>% unlist()
   outlier_range <-  1.5*IQR(vector)
-  cut_off_floor   =  quantile(vector,c(.25))[[1]] - outlier_range
-  cut_off_ceiling =   quantile(vector,c(.75))[[1]] + outlier_range
-  
+    cut_off_floor   <-  ifelse(!is.na(cut_off_floor),
+                             cut_off_floor,
+                             quantile(vector,c(.25))[[1]] - outlier_range) #if the user does not specify a cut off, a default one is introduced 
+  cut_off_ceiling   <-  ifelse(!is.na(cut_off_ceiling),
+                             cut_off_ceiling,
+                             quantile(vector,c(.75))[[1]] + outlier_range) #if the user does not specify a cut off, a default one is introduced   
   printing_min_max <- x %>% summarise_(sprintf("round(min(%s, na.rm = TRUE), 1)", var_name),
                                        sprintf("round(max(%s, na.rm = TRUE), 1)", var_name))
 

--- a/R/outlier_bin.R
+++ b/R/outlier_bin.R
@@ -40,12 +40,8 @@ gg_outlier_bin <- function(x,
   printing_min_max <- x %>% summarise_(sprintf("round(min(%s, na.rm = TRUE), 1)", var_name),
                                        sprintf("round(max(%s, na.rm = TRUE), 1)", var_name))
 
-  ceiling_filter <- ifelse(!is.na(cut_off_ceiling),
-                           sprintf("%s < %f", var_name, cut_off_ceiling),
-                           "1 == 1")
-  floor_filter   <- ifelse(!is.na(cut_off_floor),
-                           sprintf("%s > %f", var_name, cut_off_floor),
-                           "1 == 1")
+  ceiling_filter <- sprintf("%s < %f", var_name, cut_off_ceiling)
+  floor_filter   <- sprintf("%s > %f", var_name, cut_off_floor)
 
   x_regular <- x %>% filter_(ceiling_filter, floor_filter) %>%
     select_(var_name)


### PR DESCRIPTION
Dear @EdwinTh ,
after reading and commenting on your blog post about [binning outliers in histograms](https://edwinth.github.io/blog/outlier-bin/) I gave a look at your great function and thought: wouldn't be great to let the code autonomously suggest which records are to be considered as outliers and automatically bin them?
Use case: you are just performing some EDA on you freshly acquired data, and you want to gain a quick understanding of them without having to worry too much about iteratively set thresholds for outliers.
I personally found my self into this case several times :)

To implement this I have resorted to the Tukey definition of outlier threshold: 1.5 * inter quartile range. 
After performing the computation of this threshold, the code defines _cut_off_floor_ and _cut_off_ceiling_ respectively removing the threshold from the .25 percentile and adding it to the .75 percentile. This is done only if the user has not specified any values for the above mentioned variables. This is checked through an _!is.na()_ .

Hope you will appreciate this contribution.

Ciao,

A